### PR TITLE
feat: generate html pages for messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ npm start
 node src/index.js
 ```
 
+Por padrão, cada mensagem gera uma página HTML em `docs/` e um QR code que aponta para ela. Configure a variável de ambiente `BASE_URL` com a URL do seu GitHub Pages para que os links sejam gerados corretamente:
+
+```bash
+BASE_URL=https://seuusuario.github.io/qrcode-host npm start
+```
+
 ### Estrutura das mensagens
 Edite o arquivo `src/messages/mensagens.json` para adicionar suas próprias mensagens:
 

--- a/docs/1_brinde_paulo_bebidas.html
+++ b/docs/1_brinde_paulo_bebidas.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>[Paulo Bebidas] - Premiado</title>
+<style>body{font-family:Arial,sans-serif;padding:1rem;}h1{font-size:1.5rem;}p{white-space:pre-line;font-size:1.2rem;}</style>
+</head>
+<body>
+<h1>[Paulo Bebidas] - Premiado</h1>
+<p>Parabéns você ganhou um brinde!
+
+Vá ao Paulo Bebidas para retirar.</p>
+</body>
+</html>

--- a/docs/2_tente_novamente.html
+++ b/docs/2_tente_novamente.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>[Paulo Bebidas] - Não Premiado</title>
+<style>body{font-family:Arial,sans-serif;padding:1rem;}h1{font-size:1.5rem;}p{white-space:pre-line;font-size:1.2rem;}</style>
+</head>
+<body>
+<h1>[Paulo Bebidas] - Não Premiado</h1>
+<p>Infelizmente não foi dessa vez, continue tentando.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- generate HTML page for each message in docs/
- create QR codes that point to those pages using BASE_URL
- document how to set BASE_URL when generating codes

## Testing
- `BASE_URL=https://example.com npm start`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6898dc4f6c948321b403ccfe2cd40f48