### PR TITLE
Use message routes for page links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ BASE_URL=https://seuusuario.github.io/qrcode-host npm start
 ```
 
 ### Estrutura das mensagens
-Edite o arquivo `src/messages/mensagens.json` para adicionar suas próprias mensagens:
+Edite o arquivo `src/mensagens.js` para adicionar suas próprias mensagens. Cada item pode definir uma rota para gerar a página correspondente no GitHub Pages:
 
-```json
-{
-  "mensagens": [
-    {
-      "id": 1,
-      "titulo": "Seu Título",
-      "mensagem": "Sua mensagem aqui",
-      "url": "opcional - não será usado nos QR codes"
-    }
-  ]
-}
+```javascript
+const MENSAGENS = [
+  {
+    id: 1,
+    titulo: 'Seu Título',
+    mensagem: 'Sua mensagem aqui',
+    route: '/minha-rota'
+  }
+];
+
+module.exports = MENSAGENS;
 ```
 
 ### Uso programático
@@ -82,8 +82,7 @@ qrcode-host/
 ├── package.json              # Configurações do projeto
 ├── src/
 │   ├── index.js              # Código principal
-│   └── messages/
-│       └── mensagens.json    # Mensagens para gerar QR codes
+│   └── mensagens.js          # Mensagens para gerar QR codes
 └── qrcodes/                  # QR codes gerados (PNG)
     ├── qrcode_1_titulo.png
     └── ...

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,7 @@ async function gerarQRCode(mensagem, filename) {
 // Gera uma página HTML com a mensagem
 async function gerarPaginaHTML(item, filename) {
     const htmlPath = path.join(htmlDir, filename);
+    await fs.promises.mkdir(path.dirname(htmlPath), { recursive: true });
     const conteudoHTML = `<!DOCTYPE html>\n<html lang="pt-BR">\n<head>\n<meta charset="UTF-8" />\n<meta name="viewport" content="width=device-width, initial-scale=1.0" />\n<title>${item.titulo}</title>\n<style>body{font-family:Arial,sans-serif;padding:1rem;}h1{font-size:1.5rem;}p{white-space:pre-line;font-size:1.2rem;}</style>\n</head>\n<body>\n<h1>${item.titulo}</h1>\n<p>${item.mensagem}</p>\n</body>\n</html>`;
 
     await fs.promises.writeFile(htmlPath, conteudoHTML, 'utf8');
@@ -63,10 +64,11 @@ async function gerarQRCodes() {
     console.log('🚀 Gerando páginas HTML e QR codes...\n');
 
     for (const item of MENSAGENS) {
-        const htmlFilename = `${item.id}_${item.name}.html`;
+        const route = item.route ? item.route.replace(/^\//, '') : `${item.id}_${item.name}`;
+        const htmlFilename = path.join(route, 'index.html');
         await gerarPaginaHTML(item, htmlFilename);
 
-        const url = `${BASE_URL}/${htmlFilename}`;
+        const url = `${BASE_URL}${item.route || `/${route}`}`;
         const qrFilename = `qrcode_${item.id}_${item.name}`;
         await gerarQRCode(url, qrFilename);
         console.log(`🌐 URL: ${url}`);


### PR DESCRIPTION
## Summary
- Generate HTML pages inside per-message routes and build QR code URLs from those routes
- Document route property in message examples

## Testing
- `node src/index.js`


------
https://chatgpt.com/codex/tasks/task_e_6898e08dd8688321a6b18d4e9bf1f6ba